### PR TITLE
Initial Slack bot implementation with OpenAI integration

### DIFF
--- a/slack-ai-bot/.gitignore
+++ b/slack-ai-bot/.gitignore
@@ -1,0 +1,14 @@
+# Environment variables
+.env
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Logs
+*.log
+
+# ngrok
+ngrok
+ngrok-v3-stable-linux-amd64.tgz

--- a/slack-ai-bot/README.md
+++ b/slack-ai-bot/README.md
@@ -1,0 +1,38 @@
+# Slack AI Bot
+
+SlackからメッセージをAIアシスタントに送信し、応答を受け取るボットです。
+
+## 機能
+
+- Slackからのメッセージ受信
+- AIアシスタントとの対話
+- エラー通知
+
+## セットアップ
+
+1. 必要なパッケージのインストール:
+```bash
+pip install -r requirements.txt
+```
+
+2. 環境変数の設定:
+`.env`ファイルを作成し、以下の変数を設定します：
+```
+SLACK_BOT_TOKEN=xoxb-your-token
+SLACK_SIGNING_SECRET=your-signing-secret
+```
+
+3. サーバーの起動:
+```bash
+python slack_bot.py
+```
+
+## 使用方法
+
+1. Slackでボットにメッセージを送信
+2. ボットがメッセージを受信し、AIアシスタントに転送
+3. AIアシスタントからの応答がSlackに返信されます
+
+## エラー通知
+
+エラーが発生した場合や、AIのレート制限により処理が中断された場合、Slackチャンネルに通知が送信されます。

--- a/slack-ai-bot/requirements.txt
+++ b/slack-ai-bot/requirements.txt
@@ -1,0 +1,6 @@
+fastapi==0.104.1
+uvicorn==0.24.0
+python-dotenv==1.0.0
+slack-sdk==3.23.0
+openai>=1.3.3
+python-multipart==0.0.6

--- a/slack-ai-bot/slack_bot.py
+++ b/slack-ai-bot/slack_bot.py
@@ -1,0 +1,75 @@
+import os
+from fastapi import FastAPI, Request, Response
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
+from dotenv import load_dotenv
+from slack_sdk.signature import SignatureVerifier
+import openai
+import uvicorn
+import json
+
+# 環境変数の読み込み
+load_dotenv()
+
+app = FastAPI()
+slack_client = WebClient(token=os.environ.get("SLACK_BOT_TOKEN"))
+signature_verifier = SignatureVerifier(os.environ.get("SLACK_SIGNING_SECRET"))
+
+# Slack Event Subscriptionsの検証用
+@app.post("/slack/events")
+async def slack_events(request: Request):
+    # リクエストボディを取得
+    body = await request.body()
+    # ヘッダーを取得
+    headers = request.headers
+    
+    # リクエストの署名を検証
+    if not signature_verifier.is_valid_request(body, headers):
+        return {"error": "Invalid request signature"}, 403
+
+    # JSONデータを解析
+    event_data = await request.json()
+    
+    # リクエストの検証
+    if "challenge" in event_data:
+        return {"challenge": event_data["challenge"]}
+
+    # イベントの処理
+    if "event" in event_data:
+        event = event_data["event"]
+        
+        # メッセージイベントの処理
+        if event["type"] == "message" and "bot_id" not in event:
+            try:
+                channel_id = event["channel"]
+                message = event["text"]
+                
+                # メッセージを受信したことを通知
+                slack_client.chat_postMessage(
+                    channel=channel_id,
+                    text=f"メッセージを受信しました: {message}\n処理を開始します..."
+                )
+                
+                # OpenAIを使用して応答を生成
+                response = openai.chat.completions.create(
+                    model="gpt-3.5-turbo",
+                    messages=[
+                        {"role": "system", "content": "あなたは親切で丁寧なアシスタントです。"},
+                        {"role": "user", "content": message}
+                    ]
+                )
+                
+                # 応答をSlackに送信
+                ai_response = response.choices[0].message.content
+                slack_client.chat_postMessage(
+                    channel=channel_id,
+                    text=ai_response
+                )
+                
+            except SlackApiError as e:
+                print(f"Error sending message: {e.response['error']}")
+                
+    return {"status": "ok"}
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=54725)


### PR DESCRIPTION
This PR adds the initial implementation of a Slack bot that can:

- Receive messages from Slack
- Process them using OpenAI GPT-3.5-turbo
- Send responses back to Slack

Next steps will include:
- Integration with OpenHands agent functionality
- Adding file manipulation capabilities
- Adding command execution capabilities
- Implementing security controls